### PR TITLE
to Support `WECHATY_PUPPET_PUPPETEER_ENDPOINT` Environment Variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-wechat",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "description": "Puppet WeChat for Wechaty",
   "main": "dist/src/mod.js",
   "typings": "dist/src/mod.d.ts",

--- a/src/puppet-wechat.ts
+++ b/src/puppet-wechat.ts
@@ -127,7 +127,7 @@ export class PuppetWeChat extends Puppet {
 
     this.fileId = 0
     this.bridge = new Bridge({
-      endpoint      : options.endpoint,
+      endpoint      : options.endpoint || process.env.WECHATY_PUPPET_PUPPETEER_ENDPOINT,
       head          : typeof options.head === 'boolean' ? options.head : envHead(),
       launchOptions : options.launchOptions as LaunchOptions,
       memory        : this.memory,


### PR DESCRIPTION
allow to config chrome/chromium path by setting the environment variable named WECHATY_PUPPET_PUPPETEER_ENDPOINT.
It is for solve the problem `failed stated PuppetWeChatBridge` in some environment.
see: <https://github.com/wechaty/matrix-appservice-wechaty/issues/78#issuecomment-882208894>