### PR TITLE
修复主动退出登陆后，再次扫描无法登录的情况

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechaty-puppet-wechat",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "description": "Puppet WeChat for Wechaty",
   "main": "dist/src/mod.js",
   "typings": "dist/src/mod.d.ts",

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -278,6 +278,16 @@ export class Bridge extends EventEmitter {
     await page.setRequestInterception(true)
     page.on('request', async req => {
       const url = new URL(req.url())
+      if (url.pathname == "/" && url.search.indexOf("target=t") == -1) {
+           if (url.search == "" || url.search == "?") {
+                url.search = "?";
+              } else {
+                url.search += "&";
+              }
+              url.search += "target=t";
+              await req.continue({ url });
+              return;
+       }
       if (url.pathname === '/cgi-bin/mmwebwx-bin/webwxnewloginpage') {
         const override = {
           headers: {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -278,16 +278,16 @@ export class Bridge extends EventEmitter {
     await page.setRequestInterception(true)
     page.on('request', async req => {
       const url = new URL(req.url())
-      if (url.pathname == "/" && url.search.indexOf("target=t") == -1) {
-           if (url.search == "" || url.search == "?") {
-                url.search = "?";
-              } else {
-                url.search += "&";
-              }
-              url.search += "target=t";
-              await req.continue({ url });
-              return;
-       }
+      if (url.pathname === '/' && url.search.indexOf('target=t') === -1) {
+        if (url.search === '' || url.search === '?') {
+          url.search = '?'
+        } else {
+          url.search += '&'
+        }
+        url.search += 'target=t'
+        await req.continue({ url })
+        return
+      }
       if (url.pathname === '/cgi-bin/mmwebwx-bin/webwxnewloginpage') {
         const override = {
           headers: {


### PR DESCRIPTION
本地已经测试，此次加的判断应该会杜绝此类问题的发生了。由于主动退出后，网页重定向的地址没有携带`target=t`所以导致此问题